### PR TITLE
Specify button type for calculator and verify click handling

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
       </div>
     </div>
     <div class="actions-row">
-      <button id="btn-calc" class="btn primary">Calculer</button>
+      <button id="btn-calc" class="btn primary" type="button">Calculer</button>
       <button id="btn-save" class="btn">Sauvegarder l’état</button>
       <button id="btn-load" class="btn">Charger l’état</button>
       <button id="btn-reset" class="btn danger">Réinitialiser tout</button>


### PR DESCRIPTION
## Summary
- Set the Calculer button's type to `button` to avoid implicit form submission.
- Confirmed that `bootstrap()` invokes `attachCoreListeners()` which binds `calcAndRender` to the button click.

## Testing
- `node - <<'NODE' ... NODE` *(verifies handler attachment and execution)*


------
https://chatgpt.com/codex/tasks/task_e_68a7398daab08326bf5a80b161399acd