### PR TITLE
Handle missing DOM inputs before attaching listeners

### DIFF
--- a/app.js
+++ b/app.js
@@ -532,7 +532,11 @@ function attachCoreListeners(){
     dom.contrainteSol, dom.contrainteTerrain, dom.chauffage, dom.ventilation, dom.ajoutPerso,
     dom.opexHorizon, dom.opexEnergyBase, dom.opexMaintPct, dom.inflationEnergy, dom.inflationMaint, dom.discountRate
   ];
-  inputs.forEach(i => i.addEventListener('input', calcAndRender));
+  const missing = inputs.filter(i => !i);
+  if(missing.length){
+    console.warn("attachCoreListeners: éléments DOM manquants", missing);
+  }
+  inputs.filter(Boolean).forEach(i => i.addEventListener('input', calcAndRender));
   dom.btnCalc.addEventListener('click', calcAndRender);
 
   dom.chauffage.addEventListener('change', ()=>{


### PR DESCRIPTION
## Summary
- guard event listener registration against missing DOM nodes
- log a warning when expected elements are absent

## Testing
- `node --check app.js` *(fails: Invalid or unexpected token at line 398 due to existing `€` identifier)*

------
https://chatgpt.com/codex/tasks/task_e_68a73897bac883268eca9176a0350432