### PR TITLE
Use appropriate events for core input bindings

### DIFF
--- a/app.js
+++ b/app.js
@@ -532,7 +532,10 @@ function attachCoreListeners(){
     dom.contrainteSol, dom.contrainteTerrain, dom.chauffage, dom.ventilation, dom.ajoutPerso,
     dom.opexHorizon, dom.opexEnergyBase, dom.opexMaintPct, dom.inflationEnergy, dom.inflationMaint, dom.discountRate
   ];
-  inputs.forEach(i => i.addEventListener('input', calcAndRender));
+  inputs.forEach(i => {
+    const eventName = i.tagName === 'SELECT' ? 'change' : 'input';
+    i.addEventListener(eventName, calcAndRender);
+  });
   dom.btnCalc.addEventListener('click', calcAndRender);
 
   dom.chauffage.addEventListener('change', ()=>{


### PR DESCRIPTION
## Summary
- Attach `change` or `input` listeners depending on element tag in `attachCoreListeners`

## Testing
- `node - <<'NODE' ... NODE`

------
https://chatgpt.com/codex/tasks/task_e_68a73898a2148326974fd28effd02ccc